### PR TITLE
Update readmes

### DIFF
--- a/dataloading/paxo/readme.md
+++ b/dataloading/paxo/readme.md
@@ -1,6 +1,8 @@
 ### Prerequisite
 
-- Install and active the python libs as described previously
+- In order to install dependencies, first ensure that you have Python 2.7 and a corresponding version of pip.
+- With pip 2.7, you need to install the prerequisite python modules listed specifically in this directory, thus:
+> `pip install requirements.txt`
 - Paxo tries to predict mappings between two ontologies, that are present in the Ontology Lookup Service (OLS). It's also possible to try to map a list of terms with one target ontology in OLS.
 
 ### Usage (short)

--- a/dataloading/paxo/requirements.txt
+++ b/dataloading/paxo/requirements.txt
@@ -4,7 +4,6 @@ python-levenshtein
 flask
 neo4j-driver
 pyyaml
-mysql-python
 spotpy
 numpy
 matplotlib

--- a/dataloading/readme.md
+++ b/dataloading/readme.md
@@ -1,10 +1,7 @@
 
 ### Project structure
 
-- The *oxo folder* contains the scripts to create the csv raw files that are imported into oxo as 'related'
-- The *paxo folder* contains the scripts to predict mappings.
-- The *standard folder* contains a dummy standard file to demonstrate how a standard file should be formated. A standard can be used to validate the mapping result against
-
-### Installation of requirements
-To run the scripts in both folders some libaries have to be installed. This is best done in a virtualenv and followed by:
-> pip install -r requirements.txt
+- The *oxo folder* contains the scripts to load data into OxO.
+- The *paxo folder* contains the scripts to generate predicted mappings.
+  - You can evaluate paxo using a gold standard set of mappings. The *standard folder* contains an example of how the gold    
+    standard mapppings needs to be formatted. 

--- a/dataloading/readme.md
+++ b/dataloading/readme.md
@@ -3,5 +3,4 @@
 
 - The *oxo folder* contains the scripts to load data into OxO.
 - The *paxo folder* contains the scripts to generate predicted mappings.
-  - You can evaluate paxo using a gold standard set of mappings. The *standard folder* contains an example of how the gold    
-    standard mapppings needs to be formatted. 
+  - You can evaluate paxo using a gold standard set of mappings. The *standard folder* contains an example of how the gold standard mapppings needs to be formatted. 


### PR DESCRIPTION
Paxo has no mysql dependency, so modify local requirements.txt to reflect this. Also specify Python and pip version requirements (2.7) and tighten up comments.